### PR TITLE
Revamp sprite editor UI

### DIFF
--- a/poke-sprite-forge/frontend/src/App.tsx
+++ b/poke-sprite-forge/frontend/src/App.tsx
@@ -1,13 +1,10 @@
 import CanvasEditor from './CanvasEditor';
 import './App.css';
 
-function App() {
+export default function App() {
   return (
-    <div className="max-w-4xl mx-auto space-y-4 p-4">
-      <h1 className="text-3xl font-bold text-center">Poke Sprite Forge</h1>
+    <div className="h-screen w-screen bg-gray-900 text-white">
       <CanvasEditor />
     </div>
   );
 }
-
-export default App;

--- a/poke-sprite-forge/frontend/src/components/FramePanel.tsx
+++ b/poke-sprite-forge/frontend/src/components/FramePanel.tsx
@@ -1,0 +1,26 @@
+
+interface Props {
+  active: number;
+  setActive: (n: number) => void;
+  playing: boolean;
+  togglePlay: () => void;
+}
+
+export default function FramePanel({ active, setActive, playing, togglePlay }: Props) {
+  return (
+    <div className="flex items-center gap-2 p-2 bg-gray-800 border-t border-gray-700">
+      {[0,1,2,3].map(i => (
+        <button
+          key={i}
+          onClick={() => setActive(i)}
+          className={`${active === i ? 'bg-blue-600' : 'bg-gray-700'} hover:bg-gray-600 px-2 py-1 rounded`}
+        >
+          Frame {i + 1}
+        </button>
+      ))}
+      <button onClick={togglePlay} className="ml-auto bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded">
+        {playing ? 'Stop' : 'Play'}
+      </button>
+    </div>
+  );
+}

--- a/poke-sprite-forge/frontend/src/components/LeftSidebar.tsx
+++ b/poke-sprite-forge/frontend/src/components/LeftSidebar.tsx
@@ -1,0 +1,23 @@
+
+interface Props {
+  color: string;
+  setColor: (c: string) => void;
+  exportSheet: () => void;
+}
+
+export default function LeftSidebar({ color, setColor, exportSheet }: Props) {
+  return (
+    <div className="space-y-4 p-2 w-40">
+      <div>
+        <label className="block text-sm mb-1">Current Color</label>
+        <input type="color" value={color} onChange={e => setColor(e.target.value)} className="w-full" />
+      </div>
+      <div className="pt-4 border-t border-gray-700">
+        <button onClick={exportSheet} className="w-full bg-green-600 hover:bg-green-700 text-white py-1 rounded shadow">
+          Export Sprite Sheet
+        </button>
+        <p className="text-xs text-center text-gray-300 mt-1">PNG format, transparent background</p>
+      </div>
+    </div>
+  );
+}

--- a/poke-sprite-forge/frontend/src/components/ProjectModal.tsx
+++ b/poke-sprite-forge/frontend/src/components/ProjectModal.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+export interface SpriteTemplate {
+  id: string;
+  name: string;
+  description: string;
+  width: number;
+  height: number;
+  type: 'overworld' | 'battle' | 'custom';
+}
+
+interface Props {
+  templates: SpriteTemplate[];
+  onCreate: (template: SpriteTemplate, name: string) => void;
+}
+
+export default function ProjectModal({ templates, onCreate }: Props) {
+  const [selected, setSelected] = useState(templates[0]);
+  const [name, setName] = useState('');
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
+      <div className="bg-gray-800 rounded-lg shadow-xl p-6 w-11/12 max-w-3xl space-y-4">
+        <h2 className="text-xl font-bold text-center">Create New Project</h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          {templates.map(t => (
+            <button
+              key={t.id}
+              onClick={() => setSelected(t)}
+              className={`border rounded p-3 text-left hover:border-blue-400 ${selected.id === t.id ? 'border-blue-500' : 'border-gray-600'}`}
+            >
+              <div className="font-semibold">{t.name}</div>
+              <div className="text-xs text-gray-300">{t.description}</div>
+            </button>
+          ))}
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium" htmlFor="pname">Project Name</label>
+          <input id="pname" value={name} onChange={e => setName(e.target.value)} className="w-full bg-gray-700 border border-gray-600 rounded p-2" />
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <button onClick={() => onCreate(selected, name)} className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded">Create</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/poke-sprite-forge/frontend/src/components/RightSidebar.tsx
+++ b/poke-sprite-forge/frontend/src/components/RightSidebar.tsx
@@ -1,0 +1,31 @@
+
+interface Props {
+  active: string;
+  setActive: (s: string) => void;
+}
+
+const tiles = [
+  { id: 'front', label: 'Front' },
+  { id: 'back', label: 'Back' },
+  { id: 'front-shiny', label: 'Front Shiny' },
+  { id: 'back-shiny', label: 'Back Shiny' },
+];
+
+export default function RightSidebar({ active, setActive }: Props) {
+  return (
+    <div className="space-y-2 p-2 w-40">
+      <div className="font-semibold">Battle Sprites</div>
+      <div className="grid grid-cols-2 gap-2">
+        {tiles.map(t => (
+          <button
+            key={t.id}
+            onClick={() => setActive(t.id)}
+            className={`${active === t.id ? 'bg-blue-600' : 'bg-gray-700'} hover:bg-gray-600 p-2 rounded text-xs`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/poke-sprite-forge/frontend/src/components/TopBar.tsx
+++ b/poke-sprite-forge/frontend/src/components/TopBar.tsx
@@ -1,0 +1,27 @@
+
+interface Props {
+  tool: string;
+  setTool: (t: string) => void;
+  undo: () => void;
+  info: string;
+}
+
+export default function TopBar({ tool, setTool, undo, info }: Props) {
+  const btn = (id: string, label: string) => (
+    <button
+      onClick={() => setTool(id)}
+      className={`${tool === id ? 'bg-blue-600' : 'bg-gray-700'} hover:bg-gray-600 px-2 py-1 rounded`}
+    >
+      {label}
+    </button>
+  );
+  return (
+    <div className="flex items-center gap-2 p-2 bg-gray-800 border-b border-gray-700">
+      {btn('pencil', 'Pencil')}
+      {btn('eraser', 'Eraser')}
+      {btn('dropper', 'Eyedropper')}
+      <button onClick={undo} className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded">Undo</button>
+      <div className="ml-auto text-sm text-gray-300">{info}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create modular components for UI sections
- implement project selection modal and sidebars
- restructure CanvasEditor with new layout and tools
- update App to use fullscreen editor

## Testing
- `npm --prefix poke-sprite-forge/frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_68673d9e396c83339d1eb5545aa0e609