### PR TITLE
Improve sprite editor UI with zoom and import features

### DIFF
--- a/poke-sprite-forge/frontend/src/App.tsx
+++ b/poke-sprite-forge/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import './App.css';
 
 export default function App() {
   return (
-    <div className="h-screen w-screen bg-gray-900 text-white">
+    <div className="h-screen w-screen bg-gray-900 text-white overflow-hidden">
       <CanvasEditor />
     </div>
   );

--- a/poke-sprite-forge/frontend/src/components/FramePanel.tsx
+++ b/poke-sprite-forge/frontend/src/components/FramePanel.tsx
@@ -1,24 +1,48 @@
+import { useEffect, useRef } from 'react';
 
 interface Props {
   active: number;
   setActive: (n: number) => void;
   playing: boolean;
   togglePlay: () => void;
+  frames: (ImageData | null)[];
+  width: number;
+  height: number;
 }
 
-export default function FramePanel({ active, setActive, playing, togglePlay }: Props) {
+export default function FramePanel({ active, setActive, playing, togglePlay, frames, width, height }: Props) {
+  const canvasRefs = useRef<(HTMLCanvasElement | null)[]>([]);
+
+  useEffect(() => {
+    canvasRefs.current.forEach((c, idx) => {
+      if (!c) return;
+      const ctx = c.getContext('2d');
+      if (!ctx) return;
+      ctx.clearRect(0, 0, width, height);
+      const data = frames[idx];
+      if (data) ctx.putImageData(data, 0, 0);
+    });
+  }, [frames, width, height]);
+
   return (
-    <div className="flex items-center gap-2 p-2 bg-gray-800 border-t border-gray-700">
-      {[0,1,2,3].map(i => (
+    <div className="flex items-center gap-2 p-2 bg-gray-800 border-t border-gray-700 shadow">
+      {[0, 1, 2, 3].map(i => (
         <button
           key={i}
           onClick={() => setActive(i)}
-          className={`${active === i ? 'bg-blue-600' : 'bg-gray-700'} hover:bg-gray-600 px-2 py-1 rounded`}
+          className={`rounded p-1 ${active === i ? 'ring-2 ring-blue-500' : ''}`}
         >
-          Frame {i + 1}
+          <canvas
+            ref={el => {
+              canvasRefs.current[i] = el;
+            }}
+            width={width}
+            height={height}
+            style={{ width: 40, height: 40, imageRendering: 'pixelated' }}
+          />
         </button>
       ))}
-      <button onClick={togglePlay} className="ml-auto bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded">
+      <button onClick={togglePlay} className="ml-auto bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded transition">
         {playing ? 'Stop' : 'Play'}
       </button>
     </div>

--- a/poke-sprite-forge/frontend/src/components/LeftSidebar.tsx
+++ b/poke-sprite-forge/frontend/src/components/LeftSidebar.tsx
@@ -1,22 +1,36 @@
 
+import { useRef } from 'react';
+
 interface Props {
   color: string;
   setColor: (c: string) => void;
   exportSheet: () => void;
+  importSprite: (file: File) => void;
 }
 
-export default function LeftSidebar({ color, setColor, exportSheet }: Props) {
+export default function LeftSidebar({ color, setColor, exportSheet, importSprite }: Props) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const handleImport = () => fileRef.current?.click();
+  const onFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) importSprite(f);
+    e.target.value = '';
+  };
   return (
-    <div className="space-y-4 p-2 w-40">
+    <div className="space-y-4 p-2 w-44 bg-gray-800/60 rounded shadow-inner overflow-y-auto">
       <div>
         <label className="block text-sm mb-1">Current Color</label>
         <input type="color" value={color} onChange={e => setColor(e.target.value)} className="w-full" />
       </div>
-      <div className="pt-4 border-t border-gray-700">
-        <button onClick={exportSheet} className="w-full bg-green-600 hover:bg-green-700 text-white py-1 rounded shadow">
+      <div className="pt-4 border-t border-gray-700 space-y-2">
+        <button onClick={exportSheet} className="w-full bg-green-600 hover:bg-green-700 text-white py-1 rounded shadow transition">
           Export Sprite Sheet
         </button>
-        <p className="text-xs text-center text-gray-300 mt-1">PNG format, transparent background</p>
+        <button onClick={handleImport} className="w-full bg-blue-600 hover:bg-blue-700 text-white py-1 rounded shadow transition">
+          Import Sprite
+        </button>
+        <input ref={fileRef} type="file" accept="image/png" className="hidden" onChange={onFile} />
+        <p className="text-xs text-center text-gray-300">PNG format</p>
       </div>
     </div>
   );

--- a/poke-sprite-forge/frontend/src/components/RightSidebar.tsx
+++ b/poke-sprite-forge/frontend/src/components/RightSidebar.tsx
@@ -13,14 +13,14 @@ const tiles = [
 
 export default function RightSidebar({ active, setActive }: Props) {
   return (
-    <div className="space-y-2 p-2 w-40">
+    <div className="space-y-2 p-2 w-44 bg-gray-800/60 rounded shadow-inner overflow-y-auto">
       <div className="font-semibold">Battle Sprites</div>
       <div className="grid grid-cols-2 gap-2">
         {tiles.map(t => (
           <button
             key={t.id}
             onClick={() => setActive(t.id)}
-            className={`${active === t.id ? 'bg-blue-600' : 'bg-gray-700'} hover:bg-gray-600 p-2 rounded text-xs`}
+            className={`${active === t.id ? 'ring-2 ring-blue-500 bg-gray-700' : 'bg-gray-700'} hover:bg-gray-600 p-2 rounded text-xs transition`}
           >
             {t.label}
           </button>

--- a/poke-sprite-forge/frontend/src/components/TopBar.tsx
+++ b/poke-sprite-forge/frontend/src/components/TopBar.tsx
@@ -4,9 +4,12 @@ interface Props {
   setTool: (t: string) => void;
   undo: () => void;
   info: string;
+  zoom: number;
+  zoomIn: () => void;
+  zoomOut: () => void;
 }
 
-export default function TopBar({ tool, setTool, undo, info }: Props) {
+export default function TopBar({ tool, setTool, undo, info, zoom, zoomIn, zoomOut }: Props) {
   const btn = (id: string, label: string) => (
     <button
       onClick={() => setTool(id)}
@@ -16,12 +19,17 @@ export default function TopBar({ tool, setTool, undo, info }: Props) {
     </button>
   );
   return (
-    <div className="flex items-center gap-2 p-2 bg-gray-800 border-b border-gray-700">
+    <div className="flex items-center gap-2 p-2 bg-gray-800 border-b border-gray-700 shadow">
       {btn('pencil', 'Pencil')}
       {btn('eraser', 'Eraser')}
       {btn('dropper', 'Eyedropper')}
-      <button onClick={undo} className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded">Undo</button>
-      <div className="ml-auto text-sm text-gray-300">{info}</div>
+      <button onClick={undo} className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded transition">Undo</button>
+      <div className="flex items-center gap-1 ml-auto">
+        <button onClick={zoomOut} className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded transition">-</button>
+        <span className="px-1 text-sm">{zoom}x</span>
+        <button onClick={zoomIn} className="bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded transition">+</button>
+      </div>
+      <div className="ml-4 text-sm text-gray-300 whitespace-nowrap">{info}</div>
     </div>
   );
 }

--- a/poke-sprite-forge/frontend/src/index.css
+++ b/poke-sprite-forge/frontend/src/index.css
@@ -29,8 +29,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- restyle app container with overflow handling
- update sidebars with dark theme and add sprite import
- add zoom controls to the top bar
- provide frame previews with live thumbnails
- use CSS checkerboard background and remove drawn grid

## Testing
- `npm --prefix poke-sprite-forge/frontend run lint`
- `npm --prefix poke-sprite-forge/frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_686746f80714833385ff66314e17de63